### PR TITLE
correct include path of PDF.h

### DIFF
--- a/problib/include/problib/conversions.h
+++ b/problib/include/problib/conversions.h
@@ -37,7 +37,7 @@
 #ifndef PROBLIB_CONVERSIONS_H_
 #define PROBLIB_CONVERSIONS_H_
 
-#include "problib/PDF.h"
+#include "problib/pdfs/PDF.h"
 
 #include "problib/pdfs/Gaussian.h"
 #include "problib/pdfs/Mixture.h"


### PR DESCRIPTION
Computer builds, travis doesn't build
```
In file included from /home/amigo/ros/kinetic/system/src/problib/src/pdfs/Uniform.cpp:38:0:
/home/amigo/ros/kinetic/system/src/problib/include/problib/conversions.h:40:25: fatal error: problib/PDF.h: No such file or directory
compilation terminated.
```
PDF.h is located at include/problib/pdfs/PDF.h