### PR TITLE
Fix/msg gen

### DIFF
--- a/problib/CMakeLists.txt
+++ b/problib/CMakeLists.txt
@@ -63,8 +63,9 @@ add_library(problib
         include/${PROJECT_NAME}/pdfs/Hybrid.h
         include/${PROJECT_NAME}/pdfs/PMF.h)
 target_link_libraries(problib ${catkin_LIBRARIES})
+add_dependencies(problib ${${PROJECT_NAME}_EXPORTED_TARGETS})
+
 
 # add test executable
 add_executable(problib_test src/test.cpp)
 target_link_libraries(problib_test problib)
-add_dependencies(problib_test problib_generate_messages_cpp)


### PR DESCRIPTION
Fixes #3.

conversions.h does depend on the generated msg. Therefore the problib lib, should depend on the generated targets. Otherwise, if timing is wrong, the msg is not generated yet, and the header file can't be found.